### PR TITLE
Arreglado bug: open() usa UTF-8 para tildes

### DIFF
--- a/main.py
+++ b/main.py
@@ -146,7 +146,7 @@ class Limpiador:
 if __name__ == "__main__":
     import json
 
-    with open("config.json") as f:
+    with open("config.json", "r", encoding="utf-8") as f:
         config = json.load(f)
 
     limpiador = Limpiador(


### PR DESCRIPTION
Se añade encoding='utf-8' en open() para que se detecten caracteres con tilde correctamente."