### PR TITLE
fix: Usar utf-8 para leer la configuración

### DIFF
--- a/main.py
+++ b/main.py
@@ -150,7 +150,7 @@ class Limpiador:
 if __name__ == "__main__":
     import json
 
-    with open("config.json") as f:
+    with open("config.json", "r", encoding="utf-8") as f:
         config = json.load(f)
 
     limpiador = Limpiador(


### PR DESCRIPTION
Esto evita que el script crashee si algún filtro lleva tildes.